### PR TITLE
Fixed a typo

### DIFF
--- a/util/black/bk.py
+++ b/util/black/bk.py
@@ -267,7 +267,7 @@ class Shell(tmCmd.AugmentedListCmd):
             e.g.
                 bk build --conf-a-conf-arg -- --conf-not-a-conf-arg
 
-            "build args" are all passed to the underlieing build process.
+            "build args" are all passed to the underlying build process.
         """
         global blackFile, blackFileName
         # die if there is no project configuration


### PR DESCRIPTION
Fixed a typo that shows up in "bk help build".
Changed "underlieing" to "underlying".